### PR TITLE
Remove --use-mirrors option for pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
   - "pypy"
 # command to install dependencies
 install:
-  - "pip install -r requirements.txt --use-mirrors"
-  - "pip install coveralls --use-mirrors"
+  - "pip install -r requirements.txt"
+  - "pip install coveralls"
 # command to run tests
 script:
   nosetests --with-coverage --cover-package=chronos


### PR DESCRIPTION
In travis.yml, don't use-mirrors option when running pip install