### PR TITLE
add more python versions to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "nightly"
   # does not have headers provided, please ask https://launchpad.net/~pypy/+archive/ppa
   # maintainers to fix their pypy-dev package.
   - "pypy"


### PR DESCRIPTION
add python 3.4, 3.5, 3.6, and nightly versions to travis build.